### PR TITLE
feat: Yaml support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Once installed, you can use `penify-oapi-codegen` from the command line to gener
 ### Generate Code Examples
 
 ```bash
-penify-oapi-codegen -s path/to/your/openapi/schema.yaml -l language -v variant -o path/to/output/code_example
+penify-oapi-codegen -i path/to/your/openapi/schema.json -l language -v variant -o path/to/output/schema_with_code.json
 ```
 
 ### Options
@@ -44,59 +44,53 @@ penify-oapi-codegen -s path/to/your/openapi/schema.yaml -l language -v variant -
 - `-l, --language <language>`: Programming language for the code example (optional).
 - `-v, --variant <variant>`: Variant of the code generator for the specified language (optional).
 - `-o, --output <path>`: Path to the output code example file (optional).
+- `-s,`: To show list of supported languages
 
 ## Supported Code Generators
 
 The tool supports generating code examples for the following languages and variants:
 
-| Language      | Variant       |
-|---------------|---------------|
-| C             | libcurl       |
-| C#            | HttpClient    |
-| C#            | RestSharp     |
-| cURL          | cURL          |
-| Dart          | http          |
-| Go            | Native        |
-| HTTP          | HTTP          |
-| Java          | OkHttp        |
-| Java          | Unirest       |
-| JavaScript    | Fetch         |
-| JavaScript    | jQuery        |
-| JavaScript    | XHR           |
-| Kotlin        | OkHttp        |
-| NodeJs        | Axios         |
-| NodeJs        | Native        |
-| NodeJs        | Request       |
-| NodeJs        | Unirest       |
-| Objective-C   | NSURLSession  |
-| OCaml         | Cohttp        |
-| PHP           | cURL          |
-| PHP           | Guzzle        |
-| PHP           | pecl_http     |
-| PHP           | HTTP_Request2 |
-| PowerShell    | RestMethod    |
-| Python        | http.client   |
-| Python        | Requests      |
-| R             | httr          |
-| R             | RCurl         |
-| Rust          | Reqwest       |
-| Ruby          | Net:HTTP      |
-| Shell         | Httpie        |
-| Shell         | wget          |
-| Swift         | URLSession    |
+| Language       | Variant        |
+|--------------- |----------------|
+| csharp         | RestSharp      |
+| curl           | cURL           |
+| go             | Native         |
+| http           | HTTP           |
+| java           | OkHttp         |
+| java           | Unirest        |
+| javascript     | Fetch          |
+| javascript     | jQuery         |
+| javascript     | XHR            |
+| c              | libcurl        |
+| nodejs         | Axios          |
+| nodejs         | Native         |
+| nodejs         | Request        |
+| nodejs         | Unirest        |
+| objective-c    | NSURLSession   |
+| ocaml          | Cohttp         |
+| php            | cURL           |
+| php            | HTTP_Request2  |
+| php            | pecl_http      |
+| powershell     | RestMethod     |
+| python         | http.client    |
+| python         | Requests       |
+| ruby           | Net::HTTP      |
+| shell          | Httpie         |
+| shell          | wget           |
+| swift          | URLSession     |
 
 ## Examples
 
 ### Example 1: Generate Python Requests Code Example
 
 ```bash
-penify-oapi-codegen -s ./schemas/api.yaml -l Python -v Requests -o ./examples/python_requests_example.py
+penify-oapi-codegen -s ./schemas/api.json -l python -v Requests -o ./examples/schema_python_requests_example.json
 ```
 
 ### Example 2: Generate JavaScript Fetch Code Example
 
 ```bash
-penify-oapi-codegen -s ./schemas/api.yaml -l JavaScript -v Fetch -o ./examples/js_fetch_example.js
+penify-oapi-codegen -s ./schemas/api.json -l javascript -v Fetch -o ./examples/schema_js_fetch_example.json
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
+# Penify Open API Code Gen
 
-# Open API Code Gen
-
-Openapi-code-gen is a JavaScript library designed to convert OpenAPI schemas into various code examples. This tool simplifies the process of generating client libraries in different programming languages based on your API documentation.
+`penify-oapi-codegen` is a JavaScript library designed to convert OpenAPI schemas into various code examples. This tool simplifies the process of generating client libraries in different programming languages based on your API documentation.
 
 ## Features
 
@@ -10,7 +9,7 @@ Openapi-code-gen is a JavaScript library designed to convert OpenAPI schemas int
 
 ## Prerequisites
 
-Before installing `openapi-code-gen`, ensure you have the following installed:
+Before installing `penify-oapi-codegen`, ensure you have the following installed:
 
 - [Node.js](https://nodejs.org/) (version 12 or higher)
 - npm (Node package manager)
@@ -23,29 +22,28 @@ npm install -g openapi-to-postmanv2
 
 ## Installation
 
-To install `openapi-code-gen`, run the following command:
+To install `penify-oapi-codegen`, run the following command:
 
 ```bash
-npm install openapi-code-gen
+npm install penify-oapi-codegen
 ```
 
 ## Usage
 
-Once installed, you can use `openapi-code-gen` from the command line to generate code examples from your OpenAPI schemas.
+Once installed, you can use `penify-oapi-codegen` from the command line to generate code examples from your OpenAPI schemas.
 
 ### Generate Code Examples
 
 ```bash
-openapi-code-gen generate -i path/to/your/openapi/schema.yaml -l language -v variant -o path/to/output/code_example
+penify-oapi-codegen -s path/to/your/openapi/schema.yaml -l language -v variant -o path/to/output/code_example
 ```
 
 ### Options
 
-- `generate`: Generates code examples from an OpenAPI schema.
-  - `-i, --input <path>`: Path to the OpenAPI schema file (required).
-  - `-l, --language <language>`: Programming language for the code example (required).
-  - `-v, --variant <variant>`: Variant of the code generator for the specified language (required).
-  - `-o, --output <path>`: Path to the output code example file (required).
+- `-s, --source <path>`: Path to the OpenAPI schema file (required).
+- `-l, --language <language>`: Programming language for the code example (optional).
+- `-v, --variant <variant>`: Variant of the code generator for the specified language (optional).
+- `-o, --output <path>`: Path to the output code example file (optional).
 
 ## Supported Code Generators
 
@@ -92,13 +90,13 @@ The tool supports generating code examples for the following languages and varia
 ### Example 1: Generate Python Requests Code Example
 
 ```bash
-openapi-code-gen generate -i ./schemas/api.yaml -l Python -v Requests -o ./examples/python_requests_example.py
+penify-oapi-codegen -s ./schemas/api.yaml -l Python -v Requests -o ./examples/python_requests_example.py
 ```
 
 ### Example 2: Generate JavaScript Fetch Code Example
 
 ```bash
-openapi-code-gen generate -i ./schemas/api.yaml -l JavaScript -v Fetch -o ./examples/js_fetch_example.js
+penify-oapi-codegen -s ./schemas/api.yaml -l JavaScript -v Fetch -o ./examples/js_fetch_example.js
 ```
 
 ## Contributing
@@ -111,7 +109,7 @@ This project is licensed under the ISC License.
 
 ## Author
 
-[Your Name]
+sumansaurabh
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint": "^9.4.0",
     "globals": "^15.4.0",
     "jest": "^29.7.0",
+    "js-yaml": "^4.1.0",
     "uuid": "^9.0.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "penify-oapi-codegen",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A JavaScript library to convert OpenAPI schema to Postman collection and generate sample code.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "bin": {
-    "openapi-code-gen": "src/index.js"
+    "penify-oapi-codegen": "src/index.js"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "ISC",
   "dependencies": {
     "openapi-to-postmanv2": "4.21.0",
-    "postman-code-generators": "1.10.1",
+    "postman-code-generators": "^1.0.2",
     "postman-collection": "^4.4.0"
   },
   "devDependencies": {

--- a/src/OpenAPIHelper.js
+++ b/src/OpenAPIHelper.js
@@ -3,10 +3,18 @@ const { Collection, Item } = require('postman-collection');
 const codegen = require('postman-code-generators');
 const { execSync } = require('child_process');
 const yaml = require('js-yaml');
+const path = require('path');
 
 class OpenAPIHelper {
   static convertOpenAPIToPostman(openAPIPath, postmanOutputPath) {
     execSync(`openapi2postmanv2 -s ${openAPIPath} -o ${postmanOutputPath}`, { stdio: 'inherit' });
+  }
+
+  static getSupportedLanguagesAndVariants() {
+    const languages = codegen.getLanguageList();
+    const supportedLanguages = [];
+    languages.forEach(lang => lang.variants.forEach(vari => supportedLanguages.push({ language: lang.key, variant: vari.key }))) ;
+    return supportedLanguages;
   }
 
   static generateSampleCode(postmanCollectionPath, language = null, variant = null) {

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const argv = yargs(hideBin(process.argv))
   .usage('Usage: penify-oapi-codegen -s <source> -l <language> -v <variant> -o <output>')
   .option('s', {
     alias: 'source',
-    describe: 'Path to the OpenAPI JSON file',
+    describe: 'Path to the OpenAPI JSON or YAML file',
     type: 'string',
     demandOption: true
   })
@@ -36,15 +36,14 @@ const argv = yargs(hideBin(process.argv))
 const openAPIPath = argv.s;
 const language = argv.l || null;
 const variant = argv.v || null;
-const outputAPIPath = argv.o || path.resolve(`${path.basename(openAPIPath)}_with_code.json`);
+const outputAPIPath = argv.o || path.resolve(`${path.basename(openAPIPath, path.extname(openAPIPath))}_with_code.json`);
 
 if (!openAPIPath) {
-  console.error('Please provide the path to the OpenAPI JSON file.');
+  console.error('Please provide the path to the OpenAPI file.');
   process.exit(1);
 }
 
 const resolvedOpenAPIPath = path.resolve(openAPIPath);
-const file_name = path.basename(resolvedOpenAPIPath);
 const guid = uuidv4();
 
 const postmanOutputPath = path.resolve(`/tmp/openapi_schema_postman_${guid}.json`);

--- a/src/index.js
+++ b/src/index.js
@@ -8,12 +8,11 @@ const { hideBin } = require('yargs/helpers');
 
 // Parse command-line arguments
 const argv = yargs(hideBin(process.argv))
-  .usage('Usage: penify-oapi-codegen -s <source> -l <language> -v <variant> -o <output>')
-  .option('s', {
-    alias: 'source',
+  .usage('Usage: penify-oapi-codegen -i <input> -l <language> -v <variant> -o <output> \n penify-oapi-codegen -s')
+  .option('i', {
+    alias: 'input',
     describe: 'Path to the OpenAPI JSON or YAML file',
-    type: 'string',
-    demandOption: true
+    type: 'string'
   })
   .option('l', {
     alias: 'language',
@@ -30,12 +29,30 @@ const argv = yargs(hideBin(process.argv))
     describe: 'Output file path (optional)',
     type: 'string'
   })
+  .option('s', {
+    alias: 'supported-languages',
+    describe: 'Get the list of supported languages',
+    type: 'boolean'
+  })
   .help()
   .argv;
 
-const openAPIPath = argv.s;
+const openAPIPath = argv.i;
 const language = argv.l || null;
 const variant = argv.v || null;
+const showSupportedLanguages = argv.s || null;
+
+if (showSupportedLanguages) {
+  const supportedLanguages = OpenAPIHelper.getSupportedLanguagesAndVariants();
+  console.log('| Language       | Variant        |');
+  console.log('|----------------|----------------|');
+  supportedLanguages.forEach(item => {
+    console.log(`| ${item.language.padEnd(14)} | ${item.variant.padEnd(14)} |`);
+  });
+  process.exit(0);
+}
+
+
 const outputAPIPath = argv.o || path.resolve(`${path.basename(openAPIPath, path.extname(openAPIPath))}_with_code.json`);
 
 if (!openAPIPath) {


### PR DESCRIPTION
This pull request primarily focuses on renaming the `openapi-code-gen` JavaScript library to `penify-oapi-codegen` and enhancing its functionalities. The changes include updating the library name in the `README.md` and `package.json` files, adding support for YAML OpenAPI schemas, and adding a feature to display supported languages. 

Here are the most significant changes:

Renaming and version changes:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R3): The library name has been changed from `openapi-code-gen` to `penify-oapi-codegen`. All instances of the old name in the documentation have been updated to reflect this change. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L13-R12) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L26-R93)
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): The library name has been updated to `penify-oapi-codegen` and the version has been incremented from `1.0.0` to `1.0.1`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L13-R28)

Functionality enhancements:

* [`src/OpenAPIHelper.js`](diffhunk://#diff-2809d93c60b5ea6d054ad4a56f7e5bf77160f8e839734824ce4d80c06926102bR5-R19): Added support for YAML OpenAPI schemas by using the `js-yaml` library. A new method `getSupportedLanguagesAndVariants` has been added to get a list of supported languages and variants. [[1]](diffhunk://#diff-2809d93c60b5ea6d054ad4a56f7e5bf77160f8e839734824ce4d80c06926102bR5-R19) [[2]](diffhunk://#diff-2809d93c60b5ea6d054ad4a56f7e5bf77160f8e839734824ce4d80c06926102bL74-R93) [[3]](diffhunk://#diff-2809d93c60b5ea6d054ad4a56f7e5bf77160f8e839734824ce4d80c06926102bR117-R123)
* [`src/index.js`](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L11-R15): Added a new command-line option `-s` to display the list of supported languages and variants. Also, the input file extension is now considered while generating the output file name. [[1]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L11-R15) [[2]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R32-L47)

Other changes:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L114-R106): The author's name has been updated.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L13-R28): The version of the `postman-code-generators` dependency has been updated.
* [`src/OpenAPIHelper.js`](diffhunk://#diff-2809d93c60b5ea6d054ad4a56f7e5bf77160f8e839734824ce4d80c06926102bL40-R49): The location for storing the generated sample code has been changed from `sample_code` to `/tmp/sample_code`. [[1]](diffhunk://#diff-2809d93c60b5ea6d054ad4a56f7e5bf77160f8e839734824ce4d80c06926102bL40-R49) [[2]](diffhunk://#diff-2809d93c60b5ea6d054ad4a56f7e5bf77160f8e839734824ce4d80c06926102bL51)