### PR TITLE
chore: Update Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,29 @@ Once installed, you can use `penify-oapi-codegen` from the command line to gener
 
 ### Generate Code Examples
 
+#### For all supported languages
+
+It will generate OpenAPI schema for all possible language and variant.
+
+```bash
+penify-oapi-codegen -i path/to/your/openapi/schema.json -o path/to/output/schema_with_code.json
+```
+
+#### For Specific Language and Variant
+
 ```bash
 penify-oapi-codegen -i path/to/your/openapi/schema.json -l language -v variant -o path/to/output/schema_with_code.json
 ```
 
+#### Get all supported languages
+
+```bash
+penify-oapi-codegen -s
+```
+
 ### Options
 
-- `-s, --source <path>`: Path to the OpenAPI schema file (required).
+- `-i, --input <path>`: Path to the OpenAPI schema file (required).
 - `-l, --language <language>`: Programming language for the code example (optional).
 - `-v, --variant <variant>`: Variant of the code generator for the specified language (optional).
 - `-o, --output <path>`: Path to the output code example file (optional).


### PR DESCRIPTION
This pull request includes changes to the `README.md` file that enhance the documentation for using `penify-oapi-codegen` from the command line. The changes provide additional examples for generating OpenAPI schema for all supported languages and for a specific language and variant. There's also a new command to get all supported languages. Additionally, the `-s` option has been replaced with `-i` for specifying the path to the OpenAPI schema file.

Here are the main changes:

* Added a new section for generating OpenAPI schema for all supported languages. It includes a command line example using `penify-oapi-codegen` with `-i` and `-o` options.
* Updated the section for generating OpenAPI schema for a specific language and variant. The command line example remains the same.
* Added a new section to get all supported languages. It includes a command line example using `penify-oapi-codegen` with `-s` option.
* Updated the Options section. The `-s` option has been replaced with `-i` for specifying the path to the OpenAPI schema file.…argument handling, and generate sample code for all languages and variants in OpenAPIHelper